### PR TITLE
Suggestions

### DIFF
--- a/YulSemanticsCommon.thy
+++ b/YulSemanticsCommon.thy
@@ -185,7 +185,6 @@ record ('g, 'v, 't) result =
   (* which functions are currently visible *)
   funs :: "('g, 'v, 't) function_sig locals"
 
-
 datatype ('g, 'v, 't, 'z) YulResult =
   YulResult "('g, 'v, 't, 'z) result_scheme"
   (* errors can optionally carry failed state *)

--- a/YulSemanticsSingleStep.thy
+++ b/YulSemanticsSingleStep.thy
@@ -21,12 +21,11 @@ datatype ('g, 'v, 't) StackEl =
      - old locals
      - old functions context
      - signature of function being called *)
-  | ExitFunctionCall "YulIdentifier"
+  | is_ExitFunctionCall: ExitFunctionCall "YulIdentifier"
                      "'v list" 
                      "'v locals" "('g, 'v, 't) function_sig locals" 
                      "('g, 'v, 't) function_sig"
   | Expression "('v, 't) YulExpression"
-
 
 type_synonym errf = "String.literal option"
 
@@ -37,137 +36,112 @@ record ('g, 'v, 't) result =
 type_synonym ('g, 'v, 't) YulResult =
   "('g, 'v, 't, \<lparr>cont :: ('g, 'v, 't) StackEl list\<rparr>) YulResult"
 
+type_synonym ('g, 'v, 't) YulInput =
+  "('g, 'v, 't) result"
 
 fun evalYulStatement ::
 "('g, 'v, 't) YulDialect \<Rightarrow>
- ('v, 't) YulStatement \<Rightarrow> ('g, 'v, 't) YulResult \<Rightarrow>
+ ('v, 't) YulStatement \<Rightarrow> ('g, 'v, 't) YulInput \<Rightarrow>
   ('g, 'v, 't) YulResult" where
-
-"evalYulStatement _ _ (ErrorResult emsg x) = (ErrorResult emsg x)"
-
-| "evalYulStatement D st (YulResult r) =
-   YulResult (r \<lparr> cont := EnterStatement st # cont r \<rparr>)"
-
+ "evalYulStatement D st r =
+   YulResult (cont_update (\<lambda> cont . EnterStatement st # cont) r)"
 
 fun evalYulExpression ::
 "('g, 'v, 't) YulDialect \<Rightarrow>
  ('v, 't) YulExpression \<Rightarrow>
- ('g, 'v, 't) YulResult \<Rightarrow>
+ ('g, 'v, 't) YulInput \<Rightarrow>
  ('g, 'v, 't) YulResult" where
-"evalYulExpression _ _  (ErrorResult e x) = (ErrorResult e x)"
-| "evalYulExpression D (YulIdentifier idn) (YulResult r) =
+  "evalYulExpression D (YulIdentifier idn) r =
    (case map_of (locals r) idn of
     None \<Rightarrow> ErrorResult (STR ''Undefined variable '' @@ idn) (Some r)
     | Some v \<Rightarrow>
-      YulResult (r \<lparr> vals := v # vals r\<rparr>))"
+      YulResult (vals_update (\<lambda> vs . v # vs) r))"
 
-| "evalYulExpression D (YulLiteralExpression (YulLiteral v _)) (YulResult r) =
-   YulResult (r \<lparr> vals := v # vals r \<rparr>)"
+| "evalYulExpression D (YulLiteralExpression (YulLiteral v _)) r =
+   YulResult (vals_update (\<lambda> vs . v # vs) r)"
 
-| "evalYulExpression D (YulFunctionCallExpression (YulFunctionCall name args)) (YulResult r) =
+| "evalYulExpression D YUL_EXPR{ \<guillemotleft>name\<guillemotright>(\<guillemotleft>args\<guillemotright>) } r =
    (case map_of (funs r) name of
     None \<Rightarrow> ErrorResult (STR ''Undefined function '' @@ name) (Some r)
     | Some fsig \<Rightarrow>
-      YulResult (r \<lparr> cont := map Expression (rev args) @ 
+      YulResult (cont_update (\<lambda> conts . map Expression (rev args) @ 
                                    EnterFunctionCall name fsig #
                                    ExitFunctionCall name (vals r) (locals r) (funs r) fsig #
-                                   cont r \<rparr>))"
-
+                                   conts ) r))"
 
 fun yulBreak :: "('g, 'v, 't) YulDialect \<Rightarrow>
                  ('g, 'v, 't) StackEl list \<Rightarrow>
-                 ('g, 'v, 't) YulResult \<Rightarrow>
+                 ('g, 'v, 't) YulInput \<Rightarrow>
                  ('g, 'v, 't) YulResult" where
-"yulBreak D _ (ErrorResult e msg) = ErrorResult e msg"
-| "yulBreak D [] (YulResult r) = ErrorResult (STR ''Break outside loop body'') (Some r)"
-| "yulBreak D (Expression cond1 # 
-      ExitStatement (YulForLoop pre cond post body) c' f' # ct) (YulResult r) =
-      YulResult (r \<lparr> cont := ct \<rparr>)"
-| "yulBreak D (ch#ct) (YulResult r) = yulBreak D ct (YulResult (r \<lparr> cont := ct \<rparr>))"
+ "yulBreak D [] r = ErrorResult (STR ''Break outside loop body'') (Some r)"
+| "yulBreak D (ExitStatement YUL_STMT{ for {\<guillemotleft>pre\<guillemotright>} \<guillemotleft>cond\<guillemotright> {\<guillemotleft>post\<guillemotright>} {\<guillemotleft>body\<guillemotright>} } c' f' # ct) r =
+      YulResult (cont_update (\<lambda> _  . ct) r)"
+| "yulBreak D (ch#ct) r = yulBreak D ct (cont_update (\<lambda> _  . ct) r)"
 
 fun yulContinue :: "('g, 'v, 't) YulDialect \<Rightarrow>
                     ('g, 'v, 't) StackEl list \<Rightarrow>
-                    ('g, 'v, 't) YulResult \<Rightarrow>
+                    ('g, 'v, 't) YulInput \<Rightarrow>
                     ('g, 'v, 't) YulResult" where
-"yulContinue D _ (ErrorResult e msg) = ErrorResult e msg"
-| "yulContinue D [] (YulResult r) = ErrorResult (STR ''Continue outside loop body'') (Some r)"
+  "yulContinue D [] r = ErrorResult (STR ''Continue outside loop body'') (Some r)"
 | "yulContinue D (Expression cond1 # 
-      ExitStatement (YulForLoop pre cond post body) f' c' # ct)  (YulResult r) =
-   YulResult (r \<lparr> cont := ((Expression cond1 #
-      ExitStatement (YulForLoop pre cond post body) f' c' # ct))\<rparr>)"
-| "yulContinue D (ch#ct) (YulResult r) = yulContinue D ct (YulResult (r \<lparr> cont := ct \<rparr>))"
+      ExitStatement YUL_STMT{ for {\<guillemotleft>pre\<guillemotright>} \<guillemotleft>cond\<guillemotright> {\<guillemotleft>post\<guillemotright>} {\<guillemotleft>body\<guillemotright>} } f' c' # ct) r =
+   YulResult (cont_update (\<lambda> _ . ((Expression cond1 #
+      ExitStatement YUL_STMT{ for {\<guillemotleft>pre\<guillemotright>} \<guillemotleft>cond\<guillemotright> {\<guillemotleft>post\<guillemotright>} {\<guillemotleft>body\<guillemotright>} } f' c' # ct))) r)"
+| "yulContinue D (ch#ct) r = yulContinue D ct (cont_update (\<lambda> _ . ct) r)"
 
 fun yulLeave :: "('g, 'v, 't) YulDialect \<Rightarrow>
                  ('g, 'v, 't) StackEl list \<Rightarrow>
-                 ('g, 'v, 't) YulResult \<Rightarrow>
+                 ('g, 'v, 't) YulInput \<Rightarrow>
                  ('g, 'v, 't) YulResult" where
-"yulLeave D _ (ErrorResult e msg) = ErrorResult e msg"
-| "yulLeave D [] (YulResult r) = ErrorResult (STR ''Leave outside function body'') (Some r)"
-| "yulLeave D ((ExitFunctionCall idn vals_old locals_old funs_old body )#ct) (YulResult r) =
-   YulResult (r \<lparr> cont := ((ExitFunctionCall idn vals_old locals_old funs_old body)#ct) \<rparr>)"
-| "yulLeave D (ch#ct) r = yulLeave D ct r"
+  "yulLeave D [] r = ErrorResult (STR ''Leave outside function body'') (Some r)"
+| "yulLeave D (ch#ct) r = (if is_ExitFunctionCall ch then YulResult (cont_update (\<lambda> _ . ch#ct) r) else yulLeave D ct r)"
 
 (* TODO: could check to ensure stack is empty here *)
 fun evalYulEnterStatement :: "('g, 'v, 't) YulDialect \<Rightarrow>
                               ('v, 't) YulStatement \<Rightarrow> 
-                              ('g, 'v, 't) YulResult \<Rightarrow>
+                              ('g, 'v, 't) YulInput \<Rightarrow>
                               ('g, 'v, 't) YulResult"
   where
-"evalYulEnterStatement _ _ (ErrorResult e msg) = ErrorResult e msg"
+  "evalYulEnterStatement D YUL_STMT{ \<guillemotleft>ids\<guillemotright> := \<guillemotleft>e\<guillemotright> } r =
+  YulResult (cont_update (\<lambda> ct .
+    Expression e # ExitStatement YUL_STMT{ \<guillemotleft>ids\<guillemotright> := \<guillemotleft>e\<guillemotright> } (locals r) (funs r) # ct) r)"
 
-| "evalYulEnterStatement D (YulAssignmentStatement (YulAssignment ids e)) (YulResult r) =
-  YulResult (r \<lparr> cont := Expression e #
-                        ExitStatement (YulAssignmentStatement (YulAssignment ids e)) (locals r) (funs r) #
-                        cont r\<rparr>)"
+| "evalYulEnterStatement D YUL_STMT{ let \<guillemotleft>ids\<guillemotright> := \<guillemotleft>e\<guillemotright> } r =
+  YulResult (cont_update (\<lambda> ct .
+    Expression e # ExitStatement YUL_STMT{ let \<guillemotleft>ids\<guillemotright> := \<guillemotleft>e\<guillemotright> } (locals r) (funs r) # ct) r)"
 
-| "evalYulEnterStatement D (YulVariableDeclarationStatement 
-                           (YulVariableDeclaration ids (Some e))) (YulResult r) =
-  YulResult (r \<lparr> cont := Expression e # 
-                         ExitStatement (YulVariableDeclarationStatement 
-                           (YulVariableDeclaration ids (Some e))) (locals r) (funs r) #
-                         cont r \<rparr>)"
+| "evalYulEnterStatement D YUL_STMT{ if \<guillemotleft>cond\<guillemotright> {\<guillemotleft>body\<guillemotright>} } r =
+  YulResult (cont_update (\<lambda> ct . Expression cond #
+    ExitStatement YUL_STMT{ if \<guillemotleft>cond\<guillemotright> {\<guillemotleft>body\<guillemotright>} } (locals r) (funs r) # ct) r)"
 
-| "evalYulEnterStatement D (YulIf cond body) (YulResult r) =
-  YulResult (r \<lparr> cont := Expression cond #
-                          ExitStatement (YulIf cond body) (locals r) (funs r) #
-                          cont r \<rparr>)"
-
-| "evalYulEnterStatement D (YulSwitch cond cases) (YulResult r) =
-  YulResult (r \<lparr> cont := Expression cond  #
-                         ExitStatement (YulSwitch cond cases) (locals r) (funs r) #
-                         cont r \<rparr>)"
+| "evalYulEnterStatement D YUL_STMT{ switch \<guillemotleft>cond\<guillemotright> \<guillemotleft>cases\<guillemotright> } r =
+  YulResult (cont_update (\<lambda> ct .
+    Expression cond # ExitStatement YUL_STMT{ switch \<guillemotleft>cond\<guillemotright> \<guillemotleft>cases\<guillemotright> } (locals r) (funs r) # ct) r)"
 
 (* empty pre = proceed with for loop *)
-| "evalYulEnterStatement D (YulForLoop [] cond post body) (YulResult r) = 
-    YulResult (r \<lparr> cont := Expression cond # ExitStatement (YulForLoop [] cond post body) (locals r) (funs r) #
-                            cont r \<rparr>)"
+| "evalYulEnterStatement D YUL_STMT{ for {} \<guillemotleft>cond\<guillemotright> {\<guillemotleft>post\<guillemotright>} {\<guillemotleft>body\<guillemotright>} } r = 
+    YulResult (cont_update (\<lambda> ct .
+    Expression cond # ExitStatement YUL_STMT{ for {} \<guillemotleft>cond\<guillemotright> {\<guillemotleft>post\<guillemotright>} {\<guillemotleft>body\<guillemotright>} } (locals r) (funs r) # ct) r)"
 
 (* non empty pre *)
-| "evalYulEnterStatement D (YulForLoop pre cond post body) (YulResult r) = 
-    YulResult (r \<lparr> cont := EnterStatement
-                              (YulBlock (
-                                pre @ [YulForLoop [] cond post body])
-                              ) #
-                            cont r \<rparr>)"
+| "evalYulEnterStatement D YUL_STMT{ for {\<guillemotleft>pre\<guillemotright>} \<guillemotleft>cond\<guillemotright> {\<guillemotleft>post\<guillemotright>} {\<guillemotleft>body\<guillemotright>} } r = 
+    YulResult (cont_update (\<lambda> ct .
+      EnterStatement (YulBlock (pre@[YUL_STMT{ for {} \<guillemotleft>cond\<guillemotright> {\<guillemotleft>post\<guillemotright>} {\<guillemotleft>body\<guillemotright>} }])) # ct) r)"
 
-| "evalYulEnterStatement D (YulFunctionCallStatement fc) (YulResult r) =
-  (YulResult (r \<lparr> vals := []
-                , cont := Expression (YulFunctionCallExpression fc)  #
-                          ExitStatement (YulFunctionCallStatement fc) (locals r) (funs r) #
-                          cont r \<rparr>))"
+| "evalYulEnterStatement D YUL_STMT{ \<guillemotleft>f\<guillemotright>(\<guillemotleft>args\<guillemotright>) } r =
+  (YulResult (vals_update (\<lambda> _ . []) (cont_update (\<lambda> ct .
+    Expression YUL_EXPR{ \<guillemotleft>f\<guillemotright>(\<guillemotleft>args\<guillemotright>) } # ExitStatement YUL_STMT{ \<guillemotleft>f\<guillemotright>(\<guillemotleft>args\<guillemotright>) } (locals r) (funs r) # ct) r)))"
 
 
 (* does enterStatement need function scope argument? *)
-| "evalYulEnterStatement D (YulBlock sl) (YulResult r) =
+| "evalYulEnterStatement D YUL_STMT{ {\<guillemotleft>sl\<guillemotright>} } r =
   (case gatherYulFunctions (funs r) sl of
     Inr fbad \<Rightarrow> ErrorResult (STR ''Duplicate function declaration: '' @@ fbad) (Some r)
-    | Inl F \<Rightarrow> YulResult (r \<lparr> funs := F
-                            , cont := map EnterStatement sl @ 
-                                      ExitStatement (YulBlock sl) (locals r) (funs r) #
-                                      cont r
- \<rparr>))"
+    | Inl F \<Rightarrow> YulResult (funs_update (\<lambda> _ . F) (cont_update (\<lambda> ct . map EnterStatement sl @ 
+                                      ExitStatement YUL_STMT{ {\<guillemotleft>sl\<guillemotright>} } (locals r) (funs r) #
+                                      ct) r)))"
 
-| "evalYulEnterStatement _ st (YulResult r) = (YulResult (r \<lparr> cont := ExitStatement st (locals r) (funs r) # cont r \<rparr>))"
+| "evalYulEnterStatement _ st r = (YulResult (cont_update (\<lambda> ct.  ExitStatement st (locals r) (funs r) # ct) r))"
 
 (* helper functions for switch statements *)
 fun getDefault ::
@@ -193,110 +167,101 @@ fun evalYulExitStatement :: "('g, 'v, 't) YulDialect \<Rightarrow>
                              ('v, 't) YulStatement \<Rightarrow> 
                              'v locals \<Rightarrow>
                              ('g, 'v, 't) function_sig locals \<Rightarrow>
-                             ('g, 'v, 't) YulResult \<Rightarrow>
+                             ('g, 'v, 't) YulInput \<Rightarrow>
                              ('g, 'v, 't) YulResult"
   where
-"evalYulExitStatement _ _ _ _ (ErrorResult e msg) = ErrorResult e msg"
-
-| "evalYulExitStatement D (YulAssignmentStatement (YulAssignment ids e)) _ _ (YulResult r) = 
+  "evalYulExitStatement D YUL_STMT{ \<guillemotleft>ids\<guillemotright> := \<guillemotleft>_\<guillemotright> } _ _ r = 
   (if length (vals r) \<noteq> length ids then ErrorResult (STR ''Arity mismatch (exiting assignment)'') (Some r)
    else
     (case put_values (locals r) ids  (take (length ids) (vals r)) of
       None \<Rightarrow> ErrorResult (STR ''Should be dead code (exiting assignment)'') (Some r)
       | Some L1 \<Rightarrow> YulResult (r \<lparr> locals := L1, vals := []\<rparr>)))"
 
-| "evalYulExitStatement D (YulVariableDeclarationStatement (YulVariableDeclaration ids exo)) _ _ 
-                          (YulResult r) =
-  (case exo of
-    None \<Rightarrow>
-      (if length (vals r) = 0 then
+| "evalYulExitStatement D YUL_STMT{ let \<guillemotleft>ids\<guillemotright> } _ _ r = (if length (vals r) = 0 then
         (case insert_values (locals r) (strip_id_types ids) (replicate (length ids) (default_val D)) of
           None \<Rightarrow> ErrorResult (STR ''Duplicate variable declaration'') (Some r)
           | Some L1 \<Rightarrow> YulResult (r \<lparr> locals := L1, vals := []\<rparr>))
        else ErrorResult (STR ''Invalid stack (variable declaration)'') (Some r))
-    | Some _ \<Rightarrow>
-      (if length (vals r) \<noteq> length ids then ErrorResult (STR ''Arity mismatch (variable declaration + assignment)'') (Some r)
+  "
+| "evalYulExitStatement D YUL_STMT{ let \<guillemotleft>ids\<guillemotright> := \<guillemotleft>_\<guillemotright> } _ _ r =
+  (if length (vals r) \<noteq> length ids then ErrorResult (STR ''Arity mismatch (variable declaration + assignment)'') (Some r)
        else
         (case insert_values (locals r) (strip_id_types ids) (take (length ids) (vals r)) of
           None \<Rightarrow> ErrorResult (STR ''Duplicate variable declaration'') (Some r)
-          | Some L1 \<Rightarrow> YulResult (r \<lparr> locals := L1, vals := []\<rparr>))))"
+          | Some L1 \<Rightarrow> YulResult (r \<lparr> locals := L1, vals := []\<rparr>)))"
 
-| "evalYulExitStatement D (YulIf cond body) _ _ (YulResult r) =
+| "evalYulExitStatement D YUL_STMT{ if \<guillemotleft>cond\<guillemotright> {\<guillemotleft>body\<guillemotright>} } _ _ r =
   (case vals r of
     [vh] \<Rightarrow>
     (if is_truthy D vh then 
-      YulResult (r \<lparr> vals := []
-                   , cont := EnterStatement (YulBlock body) # (cont r)\<rparr>)
+      YulResult (r \<lparr> vals := [], cont := EnterStatement YUL_STMT{ {\<guillemotleft>body\<guillemotright>} } # (cont r)\<rparr>)
      else YulResult (r \<lparr> vals := [] \<rparr>))
     | _ \<Rightarrow> ErrorResult (STR ''Invalid values stack (exiting if)'') (Some r))"
 
-| "evalYulExitStatement D (YulSwitch exp scs) _ _ (YulResult r) =
+| "evalYulExitStatement D YUL_STMT{ switch \<guillemotleft>exp\<guillemotright> \<guillemotleft>scs\<guillemotright> } _ _ r =
   (case vals r of
     [vh] \<Rightarrow>
      (case nextCase scs of
       (None, _) \<Rightarrow>
         (case getDefault scs of
-          Some (YulSwitchCase None body) \<Rightarrow>
+          Some YUL_SWITCH_CASE{ default {\<guillemotleft>body\<guillemotright>} } \<Rightarrow>
             YulResult (r \<lparr> vals := []
-                         , cont := EnterStatement (YulBlock body) #
+                         , cont := EnterStatement YUL_STMT{ {\<guillemotleft>body\<guillemotright>} } #
                                    cont r \<rparr>)
           | _ \<Rightarrow> ErrorResult (STR ''No default switch case'') (Some r))
-      | (Some (YulSwitchCase (Some (YulLiteral vcond _)) body), scs') \<Rightarrow>
+      | (Some YUL_SWITCH_CASE{ case \<guillemotleft>YulLiteral vcond _\<guillemotright> {\<guillemotleft>body\<guillemotright>} }, scs') \<Rightarrow>
         (if vh = vcond then
           YulResult (r \<lparr> vals := []
-                         , cont := EnterStatement (YulBlock body) #
+                         , cont := EnterStatement YUL_STMT{ {\<guillemotleft>body\<guillemotright>} } #
                                    cont r \<rparr>)
-         else YulResult (r \<lparr> cont := ExitStatement (YulSwitch exp scs') (locals r) (funs r) #
+         else YulResult (r \<lparr> cont := ExitStatement YUL_STMT{ switch \<guillemotleft>exp\<guillemotright> \<guillemotleft>scs'\<guillemotright> } (locals r) (funs r) #
                                    cont r \<rparr>))
       | _ \<Rightarrow> ErrorResult (STR ''Should be dead code'') (Some r))
     | _ \<Rightarrow> ErrorResult (STR ''Invalid values stack (exiting switch statement)'') (Some r))"
 
 (* we have already dealt with pre at this point *)
-| "evalYulExitStatement D (YulForLoop pre cond post body) _ _ (YulResult r) = 
+| "evalYulExitStatement D YUL_STMT{ for {\<guillemotleft>pre\<guillemotright>} \<guillemotleft>cond\<guillemotright> {\<guillemotleft>post\<guillemotright>} {\<guillemotleft>body\<guillemotright>} } _ _ r = 
   (case vals r of
     [vh] \<Rightarrow>
     (if is_truthy D vh then
       YulResult (r \<lparr> vals := []
-                   , cont := (EnterStatement (YulBlock body) # 
-                              EnterStatement (YulBlock post) #
+                   , cont := (EnterStatement YUL_STMT{ {\<guillemotleft>body\<guillemotright>} } # EnterStatement YUL_STMT{ {\<guillemotleft>post\<guillemotright>} } #
                               Expression cond # 
-                              ExitStatement (YulForLoop pre cond post body) (locals r) (funs r) #
+                              ExitStatement YUL_STMT{ for {\<guillemotleft>pre\<guillemotright>} \<guillemotleft>cond\<guillemotright> {\<guillemotleft>post\<guillemotright>} {\<guillemotleft>body\<guillemotright>} } (locals r) (funs r) #
                               cont r) \<rparr>)
      else
        (YulResult (r \<lparr> vals := []
                      , cont := (cont r) \<rparr>)))
      | _ \<Rightarrow> ErrorResult (STR ''Invalid value stack (exiting ForLoop i.e. entering body)'') (Some r))"
 
-| "evalYulExitStatement D (YulFunctionCallStatement fc) _ _ (YulResult r) =
+| "evalYulExitStatement D YUL_STMT{ \<guillemotleft>_\<guillemotright>(\<guillemotleft>_\<guillemotright>) } _ _ r =
   (case vals r of
     _#_ \<Rightarrow> ErrorResult (STR ''Nonempty stack after function call statement'') (Some r)
     | [] \<Rightarrow> YulResult r)"
 
-| "evalYulExitStatement D YulBreak _ _ (YulResult r) =
-   yulBreak D (cont r) (YulResult (r \<lparr> vals := [] \<rparr>))"
+| "evalYulExitStatement D YUL_STMT{ break } _ _ r =
+   yulBreak D (cont r) (r \<lparr> vals := [] \<rparr>)"
 
-| "evalYulExitStatement D YulContinue _ _ (YulResult r) =
-   yulContinue D (cont r) (YulResult (r \<lparr> vals := [] \<rparr>))"
+| "evalYulExitStatement D YUL_STMT{ continue } _ _ r =
+   yulContinue D (cont r) (r \<lparr> vals := [] \<rparr>)"
 
-| "evalYulExitStatement D YulLeave _ _ (YulResult r) =
-   yulLeave D (cont r) (YulResult (r \<lparr> vals := [] \<rparr>))"
+| "evalYulExitStatement D YUL_STMT{ leave } _ _ r =
+   yulLeave D (cont r) (r \<lparr> vals := [] \<rparr>)"
 
-| "evalYulExitStatement D (YulBlock sl) L F (YulResult r) =
+| "evalYulExitStatement D YUL_STMT{ {\<guillemotleft>_\<guillemotright>} } L F r =
   (YulResult (r \<lparr> locals := restrict (locals r) L
                 , vals := []
                 , funs := F \<rparr>))"
 
-| "evalYulExitStatement _ _ _ _ (YulResult r) = (YulResult (r \<lparr> vals := [] \<rparr>))"
+| "evalYulExitStatement _ _ _ _ r = (YulResult (r \<lparr> vals := [] \<rparr>))"
 
 (* TODO: make sure we are handling parameter ordering correctly (w/r/t reversal) *)
 fun evalYulEnterFunctionCall :: "('g, 'v, 't) YulDialect \<Rightarrow>
                                  YulIdentifier \<Rightarrow>
                                 ('g, 'v, 't) function_sig \<Rightarrow>
-                                ('g, 'v, 't) YulResult \<Rightarrow>
+                                ('g, 'v, 't) YulInput \<Rightarrow>
                                 ('g, 'v, 't) YulResult" where
-"evalYulEnterFunctionCall _ _ _ (ErrorResult e msg) = ErrorResult e msg"
-
-| "evalYulEnterFunctionCall D name fsig (YulResult r) = 
+  "evalYulEnterFunctionCall D name fsig r = 
   (case f_sig_body fsig of
     YulBuiltin impl \<Rightarrow>
      (case impl (global r) (take (length (f_sig_arguments fsig)) (vals r)) of
@@ -322,12 +287,10 @@ fun evalYulExitFunctionCall :: "('g, 'v, 't) YulDialect \<Rightarrow>
                                 'v locals \<Rightarrow> 
                                 ('g, 'v, 't) function_sig locals \<Rightarrow>
                                 ('g, 'v, 't) function_sig \<Rightarrow>
-                                ('g, 'v, 't) YulResult \<Rightarrow>
+                                ('g, 'v, 't) YulInput \<Rightarrow>
                                 ('g, 'v, 't) YulResult" 
   where
-"evalYulExitFunctionCall _ _ _ _ _ _ (ErrorResult e msg) = ErrorResult e msg"
-
-| "evalYulExitFunctionCall D name vals_old locals_old funs_old fsig (YulResult r) =
+  "evalYulExitFunctionCall D name vals_old locals_old funs_old fsig r =
   (case f_sig_body fsig of
     YulBuiltin _ \<Rightarrow> YulResult r
     | YulFunction _ \<Rightarrow>
@@ -341,32 +304,29 @@ fun evalYulExitFunctionCall :: "('g, 'v, 't) YulDialect \<Rightarrow>
                                    , funs := funs_old \<rparr>))))"
 
 
-fun evalYulStep :: "('g, 'v, 't) YulDialect \<Rightarrow> ('g, 'v, 't) YulResult \<Rightarrow>
+fun evalYulStep :: "('g, 'v, 't) YulDialect \<Rightarrow> ('g, 'v, 't) YulInput \<Rightarrow>
                     ('g, 'v, 't) YulResult" where
-"evalYulStep D (YulResult r)=
+"evalYulStep D r =
   (case cont r of
     [] \<Rightarrow> YulResult r
-    | (EnterStatement st)#ct \<Rightarrow> evalYulEnterStatement D st (YulResult (r \<lparr> cont := ct \<rparr>))
-    | (ExitStatement st L F)#ct \<Rightarrow> evalYulExitStatement D st L F  (YulResult (r \<lparr> cont := ct \<rparr>))
-    | (Expression e)#ct \<Rightarrow> evalYulExpression D e (YulResult (r \<lparr> cont := ct \<rparr>))
+    | (EnterStatement st)#ct \<Rightarrow> evalYulEnterStatement D st (r \<lparr> cont := ct \<rparr>)
+    | (ExitStatement st L F)#ct \<Rightarrow> evalYulExitStatement D st L F  (r \<lparr> cont := ct \<rparr>)
+    | (Expression e)#ct \<Rightarrow> evalYulExpression D e (r \<lparr> cont := ct \<rparr>)
     | (EnterFunctionCall name fsig)#ct \<Rightarrow> 
        evalYulEnterFunctionCall D name fsig 
-        (YulResult (r \<lparr> cont := ct \<rparr>))
+        (r \<lparr> cont := ct \<rparr>)
     | (ExitFunctionCall name vals_old locals_old funs_old fsig)#ct \<Rightarrow> 
        evalYulExitFunctionCall D name vals_old locals_old funs_old fsig
-        (YulResult (r \<lparr> cont := ct \<rparr>))
+        (r \<lparr> cont := ct \<rparr>)
 )"
-| "evalYulStep _ r = r"
 
 fun evalYul' :: "('g, 'v, 't) YulDialect \<Rightarrow>
-                 ('g, 'v, 't) YulResult \<Rightarrow> 
+                 ('g, 'v, 't) YulInput \<Rightarrow> 
                  int \<Rightarrow>
                  ('g, 'v, 't) YulResult" where
-"evalYul' D (YulResult r) n =
+"evalYul' D r n =
   (if n \<le> 0 then (YulResult r)
-   else evalYul' D (evalYulStep D (YulResult r)) (n - 1))"
-| "evalYul' _ (ErrorResult msg x) _ =
-    ErrorResult msg x"
+   else (case evalYulStep D r of (ErrorResult msg x) \<Rightarrow> ErrorResult msg x | YulResult r \<Rightarrow> evalYul' D r (n - 1)))"
 
 fun yulInit :: "('g, 'v, 't) YulDialect \<Rightarrow> ('g, 'v,'t) result" where
 "yulInit D = \<lparr> global = init_state D
@@ -381,7 +341,7 @@ fun evalYul :: "('g, 'v, 't) YulDialect \<Rightarrow>
                 ('g, 'v, 't) YulResult" where
 "evalYul D s n =
   (let r = yulInit D in
-   evalYul' D (YulResult (r \<lparr> cont := [EnterStatement s] \<rparr>)) n)"
+   evalYul' D (r \<lparr> cont := [EnterStatement s] \<rparr>) n)"
 
 fun evalYulE :: "('g, 'v, 't) YulDialect \<Rightarrow>
                  ('v, 't) YulExpression \<Rightarrow>
@@ -389,6 +349,6 @@ fun evalYulE :: "('g, 'v, 't) YulDialect \<Rightarrow>
                  ('g, 'v, 't) YulResult" where
 "evalYulE D e n =
   (let r = yulInit D in
-  evalYul' D (YulResult (r \<lparr> cont := [Expression e] \<rparr>)) n)"
+  evalYul' D (r \<lparr> cont := [Expression e] \<rparr>) n)"
 
 end


### PR DESCRIPTION
There are a few things in here, I think you should definitely do:
- there is really no need to drag along the Error case everywhere - as seen below you it's enough to just return it.
- some of the cases (in particular ``yulLeave``) could be simplified a bit

There is also two optional parts in there, which I'd be fine with not taking over:
- It also changes the record syntax at times using update functions instead (which I could imagine to be faster).
- It extends and fixes YulSyntax slightly and uses it in the single-step semantic definition where applicable. Just have a look and think about whether you think that's easier to read or not.